### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.7
         with:
           path: ~/.cache/pip
           key: pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,33 +21,33 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.4.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Use npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.7
         with:
           path: ~/.npm
           key: npm
 
       - name: Use pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.7
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python-version }}
 
       - name: Use tox cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.7
         with:
           path: .tox
           key: tox-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
@@ -61,4 +61,4 @@ jobs:
         run: make test
 
       - name: Run codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3.1.0

--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.7
         with:
           path: ~/.cache/pip
           key: pip

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -1,0 +1,32 @@
+---
+name: Update GitHub Actions
+on:
+  schedule:
+    - cron: "0 4 1 * *" # Runs at 04:00 UTC (00:00 EDT) on the first day of the month
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  update_gitub_actions:
+    name: Update GitHub actions
+    runs-on: ubuntu-latest
+    env:
+      COMMITTER_USERNAME: Anton Samarchyan
+      COMMITTER_EMAIL: desecho@gmail.com
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.0.2
+        with:
+          # Access token with `workflow` scope is required
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@main
+        with:
+          committer_username: ${{ env.COMMITTER_USERNAME }}
+          committer_email: ${{ env.COMMITTER_EMAIL }}
+          commit_message: Update GitHub actions
+          pull_request_title: Update GitHub actions
+          # Access token with `workflow` scope is required
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+          ignore: '["saadmk11/github-actions-version-updater@main"]'

--- a/developer_doc.md
+++ b/developer_doc.md
@@ -1,5 +1,13 @@
 # Developer documentation
 
+## Cron jobs
+
+Cron jobs are run with [GitHub Actions](https://github.com/features/actions). Time zone is UTC.
+
+- `Update GitHub actions` runs at 04:00 UTC (00:00 EDT) on the first day of the month
+
+## CI/CD
+
 [GitHub Actions](https://github.com/features/actions) are used for testing and releasing.
 
 Tests are automatically run on pull requests and in master or dev branches.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release [v4.2.0](https://github.com/actions/setup-python/releases/tag/v4.2.0) on 2022-08-02T12:44:58Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.7](https://github.com/actions/cache/releases/tag/v3.0.7) on 2022-08-11T09:35:15Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.4.1](https://github.com/actions/setup-node/releases/tag/v3.4.1) on 2022-07-14T10:48:29Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v3.1.0](https://github.com/codecov/codecov-action/releases/tag/v3.1.0) on 2022-04-21T14:51:14Z
