### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.cache/pip
           key: pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,19 +35,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.npm
           key: npm
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python-version }}
 
       - name: Use tox cache
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: .tox
           key: tox-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}

--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.cache/pip
           key: pip


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.8](https://github.com/actions/cache/releases/tag/v3.0.8) on 2022-08-22T06:49:51Z
