### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.cache/pip
           key: pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
@@ -35,19 +35,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.npm
           key: npm
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python-version }}
 
       - name: Use tox cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: .tox
           key: tox-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
@@ -61,4 +61,4 @@ jobs:
         run: make test
 
       - name: Run codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.cache/pip
           key: pip


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.5.0](https://github.com/actions/setup-node/releases/tag/v3.5.0) on 2022-09-27T13:40:45Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.9](https://github.com/actions/cache/releases/tag/v3.0.9) on 2022-09-30T05:19:40Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1) on 2022-09-19T15:25:54Z
